### PR TITLE
Guard note-from-md inputs for push events

### DIFF
--- a/.github/workflows/note-from-md.yml
+++ b/.github/workflows/note-from-md.yml
@@ -33,13 +33,20 @@ jobs:
 
       - name: Resolve inputs
         id: vars
+        env:
+          INPUT_MARKDOWN_PATH: ${{ github.event.inputs.markdown_path || '' }}
+          INPUT_TONE: ${{ github.event.inputs.tone || '' }}
+          INPUT_IS_PUBLIC: ${{ github.event.inputs.is_public || '' }}
         run: |
-          MP="${{ github.event.inputs.markdown_path }}"
+          MP="${INPUT_MARKDOWN_PATH:-}"
           if [ -z "$MP" ]; then MP="articles/sample.md"; fi
-          TONE="${{ github.event.inputs.tone }}"
+
+          TONE="${INPUT_TONE:-}"
           if [ -z "$TONE" ]; then TONE="desu-masu"; fi
-          ISP="${{ github.event.inputs.is_public }}"
+
+          ISP="${INPUT_IS_PUBLIC:-}"
           if [ -z "$ISP" ]; then ISP="false"; fi
+
           echo "markdown_path=$MP" >> $GITHUB_OUTPUT
           echo "tone=$TONE" >> $GITHUB_OUTPUT
           echo "is_public=$ISP" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Add guards in Resolve inputs of `.github/workflows/note-from-md.yml`.
- Fallback to safe defaults when `github.event.inputs` are undefined (push events).
- Preserve manual overrides on `workflow_dispatch`.

## Context
- Push-triggered runs had empty `github.event.inputs.*`, causing early script failures.
- This keeps both triggers working reliably.

## Defaults
- markdown_path: articles/sample.md
- tone: desu-masu
- is_public: false

## Test plan
- workflow_dispatch: run with custom inputs; verify they propagate to steps.
- push: commit a change under `articles/*.md`; verify workflow runs and uses defaults.
- Confirm downstream steps (optimize + post) still function.