### PR TITLE
Fix input resolution for push/dispatch (parse event payload)

### DIFF
--- a/.github/workflows/note-from-md.yml
+++ b/.github/workflows/note-from-md.yml
@@ -33,18 +33,14 @@ jobs:
 
       - name: Resolve inputs
         id: vars
-        env:
-          INPUT_MARKDOWN_PATH: ${{ github.event.inputs.markdown_path || '' }}
-          INPUT_TONE: ${{ github.event.inputs.tone || '' }}
-          INPUT_IS_PUBLIC: ${{ github.event.inputs.is_public || '' }}
         run: |
-          MP="${INPUT_MARKDOWN_PATH:-}"
+          # Read workflow_dispatch inputs from event payload if present; fall back otherwise
+          MP=$(node -e 'try{const fs=require("fs");const p=JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH,"utf8"));process.stdout.write((p.inputs&&p.inputs.markdown_path)||"");}catch{process.stdout.write("");}')
+          TONE=$(node -e 'try{const fs=require("fs");const p=JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH,"utf8"));process.stdout.write((p.inputs&&p.inputs.tone)||"");}catch{process.stdout.write("");}')
+          ISP=$(node -e 'try{const fs=require("fs");const p=JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH,"utf8"));process.stdout.write((p.inputs&&p.inputs.is_public)||"");}catch{process.stdout.write("");}')
+
           if [ -z "$MP" ]; then MP="articles/sample.md"; fi
-
-          TONE="${INPUT_TONE:-}"
           if [ -z "$TONE" ]; then TONE="desu-masu"; fi
-
-          ISP="${INPUT_IS_PUBLIC:-}"
           if [ -z "$ISP" ]; then ISP="false"; fi
 
           echo "markdown_path=$MP" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Resolve inputs by parsing `$GITHUB_EVENT_PATH` JSON (`workflow_dispatch` inputs when present).
- Fallback to defaults on non-dispatch (push) events.
- Removes reliance on `${{ ... }}` expressions inside shell.

## Why
- Previous runs failed at 0s with "workflow file issue" likely due to expression evaluation in shell env or empty interpolation on push.

## Test plan
- workflow_dispatch: run with custom inputs; they should propagate.
- push: touch `articles/*.md`; workflow should run and use defaults.